### PR TITLE
Fix: Rework `set-output` and upgrade to `google-github-actions/setup-gcloud@v1`

### DIFF
--- a/.github/workflows/deploy-grpc.yml
+++ b/.github/workflows/deploy-grpc.yml
@@ -50,7 +50,7 @@ jobs:
           java-version: 11
 
       - name: Install gcloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           service_account_key: ${{ secrets.GCP_PUBLISHER_SERVICE_ACCOUNT_KEY }}
           export_default_credentials: true
@@ -63,10 +63,10 @@ jobs:
         id: get_context
         run: |
           VERSION=$([ '${{ github.ref }}' == 'refs/heads/master' ] && git rev-parse --short HEAD || ./gradlew --quiet --console=plain -Prelease.quiet -Pgpr.read.user=${{ inputs.module_name }} -Pgpr.read.key=${{ secrets.GH_PACKAGES_READ_ACCESS_TOKEN }} ${{ env.final_name }}:currentVersion | tail -n1 )
-          echo "::set-output name=version::$VERSION"
-          echo "::set-output name=image_name::eu.gcr.io/attraqt-xo/${{ env.final_name }}:$VERSION"
-          echo "::set-output name=gateway_image_name::eu.gcr.io/attraqt-xo/items-grpc-gateway:$VERSION"
-          echo "::set-output name=env::$([ '${{ github.ref }}' == 'refs/heads/master' ] && echo 'dev' || echo 'prod')"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "image_name=eu.gcr.io/attraqt-xo/${{ env.final_name }}:$VERSION" >> $GITHUB_OUTPUT
+          echo "gateway_image_name=eu.gcr.io/attraqt-xo/items-grpc-gateway:$VERSION" >> $GITHUB_OUTPUT
+          echo "env=$([ '${{ github.ref }}' == 'refs/heads/master' ] && echo 'dev' || echo 'prod')" >> $GITHUB_OUTPUT
 
       - name: Build Docker image
         run: ./gradlew -Pgpr.read.user=${{ inputs.module_name }} -Pgpr.read.key=${{ secrets.GH_PACKAGES_READ_ACCESS_TOKEN }} ${{ env.final_name }}:bootBuildImage --imageName=${{ steps.get_context.outputs.image_name }}

--- a/.github/workflows/deploy-job.yml
+++ b/.github/workflows/deploy-job.yml
@@ -49,7 +49,7 @@ jobs:
           java-version: 11
 
       - name: Install gcloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           service_account_key: ${{ secrets.GCP_PUBLISHER_SERVICE_ACCOUNT_KEY }}
           export_default_credentials: true
@@ -57,8 +57,8 @@ jobs:
       - id: get_version_env
         name: Get job version and deployment env
         run: |
-          echo "::set-output name=version::$([ '${{ github.ref }}' == 'refs/heads/master' ] && git rev-parse --short HEAD || ./gradlew --quiet --console=plain -Prelease.quiet -Pgpr.read.user=${{ inputs.module_name }} -Pgpr.read.key=${{ secrets.GH_PACKAGES_READ_ACCESS_TOKEN }} ${{ env.job_location }}:${{ env.global_job_name }}:currentVersion | tail -n1 )"
-          echo "::set-output name=env::$([ '${{ github.ref }}' == 'refs/heads/master' ] && echo 'dev' || echo 'prod')"
+          echo "version=$([ '${{ github.ref }}' == 'refs/heads/master' ] && git rev-parse --short HEAD || ./gradlew --quiet --console=plain -Prelease.quiet -Pgpr.read.user=${{ inputs.module_name }} -Pgpr.read.key=${{ secrets.GH_PACKAGES_READ_ACCESS_TOKEN }} ${{ env.job_location }}:${{ env.global_job_name }}:currentVersion | tail -n1 )" >> $GITHUB_OUTPUT
+          echo "env=$([ '${{ github.ref }}' == 'refs/heads/master' ] && echo 'dev' || echo 'prod')" >> $GITHUB_OUTPUT
 
       - name: Publish Dataflow Template
         if: ${{ env.artifactory_password == null }}

--- a/.github/workflows/publish-search-grpc.yml
+++ b/.github/workflows/publish-search-grpc.yml
@@ -37,7 +37,7 @@ jobs:
           java-version: '11'
 
       - name: Install gcloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           service_account_key: ${{ secrets.GCP_PUBLISHER_SERVICE_ACCOUNT_KEY }}
           export_default_credentials: true
@@ -54,9 +54,9 @@ jobs:
       - name: Get deployment tag, project and environment
         id: tag_env
         run: |
-          echo "::set-output name=tag::$([[ '${{ github.ref }}' == refs/heads/* ]] && git rev-parse --short HEAD || ./gradlew --quiet --console=plain -Prelease.quiet ${{ env.final_name }}:currentVersion )"
-          echo "::set-output name=project::$([ '${{ github.ref }}' == 'refs/heads/develop' ] && echo 'dev' || echo 'prod')"
-          echo "::set-output name=env::$(if [ '${{ github.ref }}' == 'refs/heads/develop' ]; then echo 'dev'; elif [ '${{ github.ref }}' == 'refs/heads/master' ]; then echo 'staging'; else echo 'prod'; fi)"
+          echo "tag=$([[ '${{ github.ref }}' == refs/heads/* ]] && git rev-parse --short HEAD || ./gradlew --quiet --console=plain -Prelease.quiet ${{ env.final_name }}:currentVersion )" >> $GITHUB_OUTPUT
+          echo "project=$([ '${{ github.ref }}' == 'refs/heads/develop' ] && echo 'dev' || echo 'prod')" >> $GITHUB_OUTPUT
+          echo "env=$(if [ '${{ github.ref }}' == 'refs/heads/develop' ]; then echo 'dev'; elif [ '${{ github.ref }}' == 'refs/heads/master' ]; then echo 'staging'; else echo 'prod'; fi)" >> $GITHUB_OUTPUT
 
       - name: Build & Publish Docker image
         run: |

--- a/.github/workflows/publish-search-job.yml
+++ b/.github/workflows/publish-search-job.yml
@@ -48,8 +48,7 @@ jobs:
         if: inputs.fetch_environment
         id: tag_env
         run: |
-          echo "::set-output name=env::$(if [ '${{ github.ref }}' == 'refs/heads/develop' ]; then echo 'testing'; elif [ '${{ github.ref }}' == 'refs/heads/master' ]; then echo 'staging'; else echo 'production'; fi)"
-
+          echo "env=$(if [ '${{ github.ref }}' == 'refs/heads/develop' ]; then echo 'testing'; elif [ '${{ github.ref }}' == 'refs/heads/master' ]; then echo 'staging'; else echo 'production'; fi)" >> $GITHUB_OUTPUT
       - name: Build jar
         run: |
           ./gradlew \
@@ -59,7 +58,7 @@ jobs:
             -Pgpr.read.key=${{ secrets.GH_PACKAGES_ATTRAQT_READ_ACCESS_TOKEN }} \
             ${{ env.job_location }}:${{ env.global_job_name }}:build --console=plain
 
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           service_account_key: ${{ secrets.GCP_PUBLISHER_SERVICE_ACCOUNT_KEY }}
           export_default_credentials: true


### PR DESCRIPTION
See:
https://github.com/google-github-actions/setup-gcloud#authorization
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/