### PR TITLE
Fix: Always fetch tag history for search CI

### DIFF
--- a/.github/workflows/publish-search-grpc.yml
+++ b/.github/workflows/publish-search-grpc.yml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Fetch tag history
         run: git fetch --prune --unshallow
-        if: contains(fromJson('["refs/heads/develop", "refs/heads/master"]'), github.ref)
 
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/publish-search-job.yml
+++ b/.github/workflows/publish-search-job.yml
@@ -52,6 +52,9 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/**') }}
 
+      - name: Fetch tag history
+        run: git fetch --prune --unshallow
+
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
As a service CI may be triggered during another job's CI, we need to retrieve all previous tags